### PR TITLE
feat: CI multi-Python matrix, doctor daemon check, garak fix, benchmark script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,20 +12,28 @@ jobs:
     strategy:
       matrix:
         node-version: [18, 20, 22]
+        python-version: ['3.12']
         python-mode: [regex-only]
         include:
           - node-version: 22
+            python-version: '3.12'
             python-mode: ast
+          - node-version: 22
+            python-version: '3.10'
+            python-mode: regex-only
+          - node-version: 22
+            python-version: '3.11'
+            python-mode: regex-only
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
       - name: Install Python dependencies (regex-only)
         if: matrix.python-mode == 'regex-only'
         run: pip install pyyaml

--- a/scripts/benchmark-daemon.js
+++ b/scripts/benchmark-daemon.js
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+// scripts/benchmark-daemon.js — Measure scan throughput: daemon (cold/warm) vs sync fallback.
+
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execFileSync } from 'child_process';
+import { performance } from 'perf_hooks';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ANALYZER_PATH = join(__dirname, '..', 'analyzer.py');
+
+const FILE_COUNT = 100;
+
+// Vulnerability patterns to spread across generated files
+const VULN_TEMPLATES = [
+  // SQL injection
+  `const query = "SELECT * FROM users WHERE id = " + req.params.id;
+db.query(query);`,
+  // Command injection
+  `const { exec } = require('child_process');
+exec("ls " + userInput);`,
+  // XSS
+  `document.innerHTML = '<div>' + userData + '</div>';`,
+  // Path traversal
+  `const filePath = './uploads/' + req.query.filename;
+fs.readFileSync(filePath);`,
+  // Hardcoded secret
+  `const API_KEY = "sk-live-abc123secret456";
+fetch(url, { headers: { Authorization: API_KEY } });`,
+  // Eval
+  `const result = eval(req.body.expression);`,
+  // Insecure random
+  `const token = Math.random().toString(36);`,
+  // Open redirect
+  `res.redirect(req.query.url);`,
+  // Prototype pollution
+  `function merge(target, source) {
+  for (const key in source) {
+    target[key] = source[key];
+  }
+}`,
+  // NoSQL injection
+  `db.collection('users').find({ username: req.body.username, password: req.body.password });`,
+];
+
+function generateFiles(dir) {
+  const files = [];
+  for (let i = 0; i < FILE_COUNT; i++) {
+    const template = VULN_TEMPLATES[i % VULN_TEMPLATES.length];
+    const filePath = join(dir, `test_${i}.js`);
+    writeFileSync(filePath, `// Generated benchmark file ${i}\n${template}\n`);
+    files.push(filePath);
+  }
+  return files;
+}
+
+async function benchmarkDaemon(files, label) {
+  // Dynamic import to avoid top-level side effects
+  const { runAnalyzerAsync } = await import('../src/utils.js');
+
+  const start = performance.now();
+  for (const f of files) {
+    await runAnalyzerAsync(f);
+  }
+  const elapsed = performance.now() - start;
+  return { label, elapsed, perFile: elapsed / files.length };
+}
+
+function benchmarkSync(files) {
+  const start = performance.now();
+  for (const f of files) {
+    try {
+      execFileSync('python3', [ANALYZER_PATH, f], {
+        encoding: 'utf-8',
+        timeout: 30000,
+      });
+    } catch {
+      // ignore errors — measuring throughput
+    }
+  }
+  const elapsed = performance.now() - start;
+  return { label: 'Sync fallback', elapsed, perFile: elapsed / files.length };
+}
+
+function fmt(ms) {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${ms.toFixed(0)}ms`;
+}
+
+function fmtPerFile(ms) {
+  return `${ms.toFixed(0)}ms`;
+}
+
+async function main() {
+  console.log('=== Daemon Benchmark ===');
+  console.log(`Files: ${FILE_COUNT}\n`);
+
+  // Create temp dir with test files
+  const tmpDir = mkdtempSync(join(tmpdir(), 'scanner-bench-'));
+  const files = generateFiles(tmpDir);
+
+  try {
+    // Run 1: Daemon cold cache
+    console.log('Running daemon (cold cache)...');
+    const cold = await benchmarkDaemon(files, 'Daemon (cold)');
+    console.log(`  ${cold.label}: ${fmt(cold.elapsed)} (${fmtPerFile(cold.perFile)}/file)`);
+
+    // Run 2: Daemon warm cache
+    console.log('Running daemon (warm cache)...');
+    const warm = await benchmarkDaemon(files, 'Daemon (warm)');
+    console.log(`  ${warm.label}: ${fmt(warm.elapsed)} (${fmtPerFile(warm.perFile)}/file)`);
+
+    const warmVsCold = cold.elapsed / warm.elapsed;
+    console.log(`  ${warmVsCold.toFixed(1)}x speedup over cold\n`);
+
+    // Run 3: Sync fallback (shutdown daemon first)
+    console.log('Running sync fallback...');
+    const { shutdownDaemon } = await import('../src/utils.js');
+    await shutdownDaemon();
+
+    const sync = benchmarkSync(files);
+    console.log(`  ${sync.label}: ${fmt(sync.elapsed)} (${fmtPerFile(sync.perFile)}/file)\n`);
+
+    // Summary
+    const coldSpeedup = sync.elapsed / cold.elapsed;
+    const warmSpeedup = sync.elapsed / warm.elapsed;
+
+    console.log('=== Summary ===');
+    console.log(`Daemon (cold):   ${fmt(cold.elapsed).padStart(8)} (${fmtPerFile(cold.perFile)}/file)`);
+    console.log(`Daemon (warm):   ${fmt(warm.elapsed).padStart(8)} (${fmtPerFile(warm.perFile)}/file)  — ${warmVsCold.toFixed(1)}x speedup over cold`);
+    console.log(`Sync fallback:   ${fmt(sync.elapsed).padStart(8)} (${fmtPerFile(sync.perFile)}/file)`);
+    console.log(`Daemon speedup:  ${coldSpeedup.toFixed(1)}x (cold) / ${warmSpeedup.toFixed(1)}x (warm) vs sync`);
+  } finally {
+    // Cleanup
+    rmSync(tmpDir, { recursive: true, force: true });
+
+    // Shutdown daemon
+    try {
+      const { shutdownDaemon } = await import('../src/utils.js');
+      await shutdownDaemon();
+    } catch {}
+  }
+}
+
+main().catch((err) => {
+  console.error('Benchmark failed:', err.message);
+  process.exit(1);
+});

--- a/src/cli/doctor.js
+++ b/src/cli/doctor.js
@@ -3,6 +3,7 @@ import { readFileSync, existsSync, writeFileSync, copyFileSync, mkdirSync } from
 import { dirname, join } from "path";
 import { homedir, platform } from "os";
 import { fileURLToPath } from "url";
+import { getDaemonClient } from '../daemon-client.js';
 
 // Handle both ESM and CJS bundling (Smithery bundles to CJS)
 let __dirname;
@@ -156,6 +157,18 @@ export async function runDoctor(args) {
     console.log(`    \u2713 daemon.py found`);
   } else {
     console.log(`    \u26a0 daemon.py not found (daemon mode unavailable, sync fallback will be used)`);
+  }
+
+  // 3c. Daemon live health check
+  if (existsSync(daemonPath) && pythonCmd) {
+    try {
+      const client = getDaemonClient();
+      const health = await client.health();
+      console.log(`    \u2713 Daemon responding (pid=${health.pid}, cache=${health.cache_size}, uptime=${health.uptime.toFixed(1)}s)`);
+      await client.shutdown();
+    } catch (e) {
+      console.log(`    \u26a0 Daemon health check failed: ${e.message}`);
+    }
   }
 
   // 4. Python can import yaml (analyzer dependency check)

--- a/tests/garak-validation.test.js
+++ b/tests/garak-validation.test.js
@@ -105,7 +105,12 @@ describe('Garak Red-Team Validation', () => {
   }, 30000);
 
   afterAll(async () => {
-    await client.stop();
+    try {
+      await Promise.race([
+        client.stop(),
+        new Promise(r => setTimeout(r, 10000))  // 10s max for cleanup
+      ]);
+    } catch {}
 
     // Print summary table
     const summary = {};
@@ -127,7 +132,7 @@ describe('Garak Red-Team Validation', () => {
         console.log(`  [${icon}] ${p.name} -> action=${p.action}, risk=${p.riskScore}, findings=${p.findingsCount}`);
       }
     }
-  });
+  }, 120000);
 
   describe('Encoding probes', () => {
     for (const probe of ENCODING_PROBES) {


### PR DESCRIPTION
## Summary

Follow-up improvements after ClawProof plugin merge (PR #12 / v3.10.0):

- **CI**: Parameterized Python version in matrix (3.10, 3.11, 3.12), validating regex fallback across versions
- **Doctor**: Live daemon health check — starts daemon, confirms response (pid, cache, uptime), shuts down gracefully
- **Tests**: Race timeout on garak `afterAll` teardown to prevent infinite hangs + explicit 120s hook timeout
- **Scripts**: `scripts/benchmark-daemon.js` — developer benchmark comparing cold/warm daemon vs sync fallback throughput

## Test plan

- [ ] CI workflow runs successfully with Python 3.10, 3.11, and 3.12
- [ ] `npx scanner doctor` performs daemon health check without hanging
- [ ] `npm test` completes without garak teardown hang
- [ ] `node scripts/benchmark-daemon.js` produces throughput comparison output

🤖 Generated with [Claude Code](https://claude.com/claude-code)