### PR TITLE
fix: normalize confidence case across config filtering and semantic output

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -172,8 +172,9 @@ export function meetsSeverityThreshold(severity, config) {
 }
 
 export function meetsConfidenceThreshold(confidence, config) {
-  const threshold = config.confidence_threshold || 'LOW';
-  const confidenceLevel = CONFIDENCE_ORDER[confidence] ?? 0;
+  const threshold = String(config.confidence_threshold || 'LOW').toUpperCase();
+  const normalizedConfidence = String(confidence || 'LOW').toUpperCase();
+  const confidenceLevel = CONFIDENCE_ORDER[normalizedConfidence] ?? 0;
   const thresholdLevel = CONFIDENCE_ORDER[threshold] ?? 0;
   return confidenceLevel >= thresholdLevel;
 }

--- a/src/semantic-integration.js
+++ b/src/semantic-integration.js
@@ -46,7 +46,7 @@ export async function runSemanticAnalysis(filePath, options = {}) {
       column: 0,
       length: 0,
       severity: mapSeverity(f.severity),
-      confidence: f.confidence || 'medium',
+      confidence: (f.confidence ? String(f.confidence) : 'MEDIUM').toUpperCase(),
       metadata: {
         category: f.category,
         engine: 'semantic',

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -138,6 +138,17 @@ describe('meetsConfidenceThreshold', () => {
   it('should pass MEDIUM when threshold is MEDIUM', () => {
     expect(meetsConfidenceThreshold('MEDIUM', { confidence_threshold: 'MEDIUM' })).toBe(true);
   });
+
+  it('should treat lowercase confidence as valid values', () => {
+    expect(meetsConfidenceThreshold('medium', { confidence_threshold: 'MEDIUM' })).toBe(true);
+    expect(meetsConfidenceThreshold('high', { confidence_threshold: 'MEDIUM' })).toBe(true);
+    expect(meetsConfidenceThreshold('low', { confidence_threshold: 'MEDIUM' })).toBe(false);
+  });
+
+  it('should treat lowercase threshold as valid', () => {
+    expect(meetsConfidenceThreshold('MEDIUM', { confidence_threshold: 'medium' })).toBe(true);
+    expect(meetsConfidenceThreshold('LOW', { confidence_threshold: 'medium' })).toBe(false);
+  });
 });
 
 describe('applyConfig', () => {
@@ -172,6 +183,17 @@ describe('applyConfig', () => {
     const result = applyConfig(findings, 'test.js', config);
     expect(result).toHaveLength(1);
     expect(result[0].ruleId).toBe('sql-injection');
+  });
+
+  it('should preserve semantic findings with lowercase confidence when threshold is MEDIUM', () => {
+    const config = { suppress: [], severity_threshold: 'info', confidence_threshold: 'MEDIUM' };
+    const findings = [
+      { ruleId: 'semantic-rule', severity: 'warning', confidence: 'medium' },
+      { ruleId: 'low-confidence', severity: 'warning', confidence: 'low' },
+    ];
+    const result = applyConfig(findings, 'test.js', config);
+    expect(result).toHaveLength(1);
+    expect(result[0].ruleId).toBe('semantic-rule');
   });
 
   it('should handle null config', () => {


### PR DESCRIPTION
## Summary
Normalize confidence casing so threshold filtering behaves consistently across engines, including semantic findings.

## Problem
Semantic integration can emit lowercase confidence (for example `medium`) while threshold checks use uppercase levels (`LOW|MEDIUM|HIGH`). This can cause findings to be filtered incorrectly.

## Changes
- `src/config.js`
  - Normalize both finding confidence and configured `confidence_threshold` to uppercase in `meetsConfidenceThreshold`.
- `src/semantic-integration.js`
  - Normalize emitted semantic finding confidence to uppercase (`MEDIUM` default).
- `tests/config.test.js`
  - Added regression tests for lowercase/mixed-case confidence and thresholds.
  - Added regression test proving lowercase semantic-style confidence is preserved correctly at `MEDIUM` threshold.

## Verification
- `npx vitest run tests/config.test.js` (pass)
- `npx vitest run tests/scan-security.test.js tests/semantic-analysis.test.js` (pass)

Fixes #70
