### PR TITLE
chore: add ProofLayer brand mention to README and package description

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Scans code for vulnerabilities, detects hallucinated packages, blocks prompt injection, and provides LLM-powered semantic code review — via MCP (Claude Code, Cursor, Windsurf, Cline) or CLI (OpenClaw, CI/CD).
 
+> Part of the [**ProofLayer**](https://www.proof-layer.com) open-core security platform. This scanner is the pre-deployment / static-analysis surface; for runtime protection of MCP servers in production, see [`prooflayer-runtime`](https://github.com/sinewaveai/prooflayer-runtime).
+
 [![npm downloads](https://img.shields.io/npm/dt/agent-security-scanner-mcp.svg)](https://www.npmjs.com/package/agent-security-scanner-mcp)
 [![npm version](https://img.shields.io/npm/v/agent-security-scanner-mcp.svg)](https://www.npmjs.com/package/agent-security-scanner-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-security-scanner-mcp",
   "version": "4.3.0",
   "mcpName": "io.github.sinewaveai/agent-security-scanner-mcp",
-  "description": "Security scanner MCP server for AI coding agents. Prompt injection firewall, package hallucination detection (4.3M+ packages), 1700+ vulnerability rules with AST & taint analysis, LLM-powered semantic code review, auto-fix. For Claude Code, Cursor, Windsurf, Cline, OpenClaw.",
+  "description": "Security scanner MCP server for AI coding agents — part of the ProofLayer open-core security platform. Prompt injection firewall, package hallucination detection (4.3M+ packages), 1700+ vulnerability rules with AST & taint analysis, LLM-powered semantic code review, auto-fix. For Claude Code, Cursor, Windsurf, Cline, OpenClaw.",
   "main": "index.js",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Adds a soft mention of the ProofLayer open-core security platform near the top of the README, clarifying how this scanner relates to the broader product surface (`prooflayer-runtime` for runtime MCP protection).
- Updates `package.json` description to surface the ProofLayer brand association in npm search results.
- No rename, no npm scope change — preserves existing GitHub stars, npm dependents, and search positioning.

## Why

Part of a wider open-core split: the scanner stays as the OSS engagement footprint (pre-deployment / static analysis), while runtime MCP defense lives in the new public `prooflayer-runtime` repo. This change keeps the scanner's identity intact while making the platform relationship explicit.

## Test plan

- [ ] Verify README renders correctly on github.com (relative links + cross-repo link to `prooflayer-runtime`)
- [ ] `npm view agent-security-scanner-mcp description` reflects the updated description after next publish
- [ ] No CI changes; existing test suite continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)