### PR TITLE
chore(release): 4.4.0 — fix missing src files in published tarball

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.0] - 2026-05-12
+
+### Fixed
+
+- **Packaging:** `src/semantic-integration.js`, `src/semantic-analyzer.js`, `src/utils/github-clone.js`, and `src/utils/npm-download.js` are now included in the published tarball. Prior versions imported these files at runtime (from `src/tools/scan-security.js` and `src/cli/scan-clawhub-full.js`) but did not ship them, causing `ERR_MODULE_NOT_FOUND` when the package was installed globally and used via the composite GitHub Action.
+
+### Dependencies
+
+- chore(deps): bump fast-uri 3.1.0 → 3.1.2 (root, scanner-lite, mcp-server-full, prooflayer-scanner) (#82, #84, #83, #86)
+- chore(deps): bump hono 4.12.16 → 4.12.18 (root) and 4.12.14 → 4.12.18 (scanner-lite, mcp-server-full, prooflayer-scanner) (#85, #80, #79, #81)
+- chore(deps): bump ip-address 10.1.0 → 10.2.0 and express-rate-limit 8.3.0 → 8.5.1 (mcp-server-full, prooflayer-scanner) (#77, #78)
+
 ## [4.3.0] - 2026-05-05
 
 ### 🔒 Critical Security Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-security-scanner-mcp",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-security-scanner-mcp",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1486,6 +1486,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1723,6 +1724,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2076,6 +2078,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2552,6 +2555,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2760,6 +2764,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-security-scanner-mcp",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "mcpName": "io.github.sinewaveai/agent-security-scanner-mcp",
   "description": "Security scanner MCP server for AI coding agents. Prompt injection firewall, package hallucination detection (4.3M+ packages), 1700+ vulnerability rules with AST & taint analysis, LLM-powered semantic code review, auto-fix. For Claude Code, Cursor, Windsurf, Cline, OpenClaw.",
   "main": "index.js",
@@ -95,6 +95,9 @@
     "src/python.js",
     "src/plugin-config.js",
     "src/plugin-health.js",
+    "src/semantic-integration.js",
+    "src/semantic-analyzer.js",
+    "src/utils/*.js",
     "openclaw.plugin.json",
     "templates/**",
     "analyzer.py",


### PR DESCRIPTION
## Summary

- Bump version 4.3.0 → 4.4.0
- **Bug fix:** add `src/semantic-integration.js`, `src/semantic-analyzer.js`, and `src/utils/*.js` to the `files` array in `package.json`. Prior releases imported these at runtime but did not ship them, breaking `agent-security-scanner-mcp` when installed globally and invoked via the composite Security Scan action (`ERR_MODULE_NOT_FOUND` on `src/tools/scan-security.js`).
- Roll up dependabot bumps merged this week (fast-uri, hono, ip-address, express-rate-limit) across root and the `scanner-lite` / `mcp-server-full` / `prooflayer-scanner` sub-packages.

## Verification

`npm pack --dry-run` now includes the four previously-missing files:

```
src/semantic-integration.js
src/semantic-analyzer.js
src/utils/github-clone.js
src/utils/npm-download.js
```

A full sweep of every shipped `.js` file confirmed no other relative imports resolve to a file outside the tarball.

## Release process

1. Merge this PR.
2. Tag `v4.4.0` on `main`.
3. Create a GitHub release from the tag — that fires `publish-gpr.yml` (GitHub Packages).
4. Publish to public npm registry: `npm publish` from a clean checkout (manual step — no workflow handles this).

## Test plan

- [ ] CI passes on this PR (tests, benchmark)
- [ ] `Security Scan` check still fails (expected — it installs the currently published 4.3.0 which has the bug). It should pass on the next PR after 4.4.0 is published to npm.
- [ ] After publishing, verify locally: `npx agent-security-scanner-mcp@4.4.0 scan-security <file>` runs without `ERR_MODULE_NOT_FOUND`.