### PR TITLE
fix(scan-project): replace blanket dotfile skip with directory denylist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.1] - 2026-05-19
+
+### Fixed
+
+- **`scan-project` dotpath blind spot:** the directory walk skipped every entry beginning with `.`, so security-relevant dotpaths (e.g. `.github/workflows`, `.github/scripts`) and their scannable source files were never analyzed. The blanket hidden-entry skip is replaced with an explicit `SKIP_DIRECTORIES` denylist. Scannable files inside dotpaths are now traversed, while VCS metadata (`.git`), dependency trees, build artifacts, language/tool caches, and editor state remain pruned. (#90, fixes #68)
+
 ## [4.4.0] - 2026-05-12
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-security-scanner-mcp",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "mcpName": "io.github.sinewaveai/agent-security-scanner-mcp",
   "description": "Security scanner MCP server for AI coding agents. Prompt injection firewall, package hallucination detection (4.3M+ packages), 1700+ vulnerability rules with AST & taint analysis, LLM-powered semantic code review, auto-fix. For Claude Code, Cursor, Windsurf, Cline, OpenClaw.",
   "main": "index.js",

--- a/src/tools/scan-project.js
+++ b/src/tools/scan-project.js
@@ -24,6 +24,30 @@ const SCANNABLE_EXTENSIONS = new Set([
   '.tf', '.hcl', '.sql',
 ]);
 
+// Directories pruned during the walk: VCS metadata, dependency trees, build
+// artifacts, language/tool caches, and editor state. Hidden entries are NOT
+// blanket-skipped — only names in this denylist are pruned — so that
+// security-relevant dotpaths (e.g. .github/workflows) are still traversed.
+const SKIP_DIRECTORIES = new Set([
+  // VCS metadata
+  '.git', '.svn', '.hg', '.bzr',
+  // Dependencies / package trees
+  'node_modules', 'vendor', 'bower_components',
+  // Build / output artifacts
+  'dist', 'build', 'out', 'target', 'coverage',
+  // Python environments and caches
+  '__pycache__', 'venv', 'env', '.venv',
+  '.tox', '.nox', '.pytest_cache', '.mypy_cache', '.ruff_cache', '.hypothesis',
+  // JS/TS framework and tooling caches
+  '.next', '.nuxt', '.svelte-kit', '.turbo', '.parcel-cache', '.cache',
+  // Package-manager caches
+  '.yarn', '.pnpm-store', '.bundle', '.cargo', '.gradle',
+  // Editor / IDE state
+  '.idea', '.vscode', '.vs',
+  // IaC state
+  '.terraform',
+]);
+
 // Parse .gitignore into patterns
 function parseGitignore(dirPath) {
   const gitignorePath = join(dirPath, '.gitignore');
@@ -64,9 +88,6 @@ function walkDirectory(dirPath, options = {}) {
     }
 
     for (const entry of entries) {
-      // Skip hidden directories/files
-      if (entry.startsWith('.')) continue;
-
       const fullPath = join(currentDir, entry);
       const relativePath = relative(dirPath, fullPath);
 
@@ -78,9 +99,10 @@ function walkDirectory(dirPath, options = {}) {
       }
 
       if (stat.isDirectory()) {
-        // Skip common non-source directories
-        if (['node_modules', 'vendor', 'dist', 'build', '__pycache__', '.git',
-             'venv', 'env', '.venv', 'target', 'coverage'].includes(entry)) continue;
+        // Prune known heavy/internal dirs (incl. hidden ones like .git), but
+        // do not blanket-skip every dotdir — security-relevant paths such as
+        // .github/workflows must still be walked.
+        if (SKIP_DIRECTORIES.has(entry)) continue;
 
         // Skip gitignored directories
         if (isGitignored(relativePath, gitignorePatterns)) continue;

--- a/tests/scan-project.test.js
+++ b/tests/scan-project.test.js
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
-import { existsSync } from 'fs';
+import { describe, it, expect, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
+import { tmpdir } from 'os';
 
 describe('scan-project module', () => {
   it('should export scanProjectSchema and scanProject', async () => {
@@ -77,4 +78,52 @@ describe('scan-project module', () => {
     expect(output.files_scanned).toBe(0);
     expect(output.grade).toBe('A');
   });
+});
+
+// Regression: scan-project blanket dotfile skip missed security-relevant
+// dotpaths such as .github/. See issue #68.
+describe('scan-project dotpath traversal', () => {
+  let tmp;
+
+  afterEach(() => {
+    if (tmp) {
+      try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+      tmp = undefined;
+    }
+  });
+
+  it('scans scannable files inside security-relevant dotpaths (.github)', async () => {
+    const { scanProject } = await import('../src/tools/scan-project.js');
+    tmp = mkdtempSync(join(tmpdir(), 'scanproj-dotpath-'));
+    mkdirSync(join(tmp, '.github', 'scripts'), { recursive: true });
+    writeFileSync(
+      join(tmp, '.github', 'scripts', 'deploy.py'),
+      'import subprocess\ndef run(cmd):\n    subprocess.call(cmd, shell=True)\n'
+    );
+
+    const result = await scanProject({ directory_path: tmp, verbosity: 'full' });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.scanned_files).toContain(join('.github', 'scripts', 'deploy.py'));
+  }, 30000);
+
+  it('still prunes .git and other heavy directories', async () => {
+    const { scanProject } = await import('../src/tools/scan-project.js');
+    tmp = mkdtempSync(join(tmpdir(), 'scanproj-deny-'));
+
+    mkdirSync(join(tmp, '.git', 'hooks'), { recursive: true });
+    writeFileSync(join(tmp, '.git', 'hooks', 'evil.py'), 'import os\nos.system("rm -rf /tmp/x")\n');
+
+    mkdirSync(join(tmp, 'node_modules', 'pkg'), { recursive: true });
+    writeFileSync(join(tmp, 'node_modules', 'pkg', 'index.js'), 'eval(globalThis.userInput)\n');
+
+    // A real source file so the scan has something to traverse.
+    writeFileSync(join(tmp, 'app.py'), 'print("hello")\n');
+
+    const result = await scanProject({ directory_path: tmp, verbosity: 'full' });
+    const output = JSON.parse(result.content[0].text);
+    const scanned = output.scanned_files || [];
+    expect(scanned.some(f => f.split(/[\\/]/).includes('.git'))).toBe(false);
+    expect(scanned.some(f => f.split(/[\\/]/).includes('node_modules'))).toBe(false);
+    expect(scanned).toContain('app.py');
+  }, 30000);
 });

--- a/tests/scan-project.test.js
+++ b/tests/scan-project.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { scanProject } from '../src/tools/scan-project.js';
 
 describe('scan-project module', () => {
   it('should export scanProjectSchema and scanProject', async () => {
@@ -83,22 +84,24 @@ describe('scan-project module', () => {
 // Regression: scan-project blanket dotfile skip missed security-relevant
 // dotpaths such as .github/. See issue #68.
 describe('scan-project dotpath traversal', () => {
-  let tmp;
+  const tmpDirs = [];
 
   afterEach(() => {
-    if (tmp) {
-      try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
-      tmp = undefined;
+    while (tmpDirs.length > 0) {
+      const dir = tmpDirs.pop();
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
     }
   });
 
   it('scans scannable files inside security-relevant dotpaths (.github)', async () => {
-    const { scanProject } = await import('../src/tools/scan-project.js');
-    tmp = mkdtempSync(join(tmpdir(), 'scanproj-dotpath-'));
+    const tmp = mkdtempSync(join(tmpdir(), 'scanproj-dotpath-'));
+    tmpDirs.push(tmp);
     mkdirSync(join(tmp, '.github', 'scripts'), { recursive: true });
+    // Benign content: the assertion verifies traversal/inclusion via
+    // scanned_files, not vulnerability detection.
     writeFileSync(
       join(tmp, '.github', 'scripts', 'deploy.py'),
-      'import subprocess\ndef run(cmd):\n    subprocess.call(cmd, shell=True)\n'
+      'def deploy():\n    return "ok"\n'
     );
 
     const result = await scanProject({ directory_path: tmp, verbosity: 'full' });
@@ -107,17 +110,17 @@ describe('scan-project dotpath traversal', () => {
   }, 30000);
 
   it('still prunes .git and other heavy directories', async () => {
-    const { scanProject } = await import('../src/tools/scan-project.js');
-    tmp = mkdtempSync(join(tmpdir(), 'scanproj-deny-'));
+    const tmp = mkdtempSync(join(tmpdir(), 'scanproj-deny-'));
+    tmpDirs.push(tmp);
 
     mkdirSync(join(tmp, '.git', 'hooks'), { recursive: true });
-    writeFileSync(join(tmp, '.git', 'hooks', 'evil.py'), 'import os\nos.system("rm -rf /tmp/x")\n');
+    writeFileSync(join(tmp, '.git', 'hooks', 'hook.py'), 'def hook():\n    return True\n');
 
     mkdirSync(join(tmp, 'node_modules', 'pkg'), { recursive: true });
-    writeFileSync(join(tmp, 'node_modules', 'pkg', 'index.js'), 'eval(globalThis.userInput)\n');
+    writeFileSync(join(tmp, 'node_modules', 'pkg', 'index.js'), 'export function pkg() {\n  return 1;\n}\n');
 
     // A real source file so the scan has something to traverse.
-    writeFileSync(join(tmp, 'app.py'), 'print("hello")\n');
+    writeFileSync(join(tmp, 'app.py'), 'def main():\n    return 0\n');
 
     const result = await scanProject({ directory_path: tmp, verbosity: 'full' });
     const output = JSON.parse(result.content[0].text);


### PR DESCRIPTION
## Summary

`scan-project`'s directory walk skipped **every** entry starting with `.`, so security-relevant dotpaths (e.g. `.github/workflows`, `.github/scripts`) were never traversed and their scannable source files were silently excluded.

This replaces the blanket hidden-entry skip with an explicit `SKIP_DIRECTORIES` denylist. Hidden entries are no longer blanket-skipped — only known heavy/internal directories are pruned — so scannable files inside dotpaths are now analyzed while `.git`, dependency trees, build artifacts, language/tool caches, and editor state remain pruned.

Closes #68

## Changes

- `src/tools/scan-project.js`
  - Removed `if (entry.startsWith('.')) continue;` blanket skip.
  - Added module-level `SKIP_DIRECTORIES` denylist (supersedes the inline non-source-dir array). Preserves the previous skip set (`node_modules`, `vendor`, `dist`, `build`, `__pycache__`, `.git`, `venv`, `env`, `.venv`, `target`, `coverage`) and adds common hidden caches/VCS/editor dirs (`.svn`, `.hg`, `.tox`, `.pytest_cache`, `.mypy_cache`, `.next`, `.cache`, `.idea`, `.vscode`, `.terraform`, etc.).
- `tests/scan-project.test.js`
  - New test: scannable file inside `.github/` is included in the scan.
  - New test: `.git` and `node_modules` remain pruned while a normal source file is still scanned.

## Scope note

This addresses the issue's explicit "Suggested Fix" (directory-walk denylist) and Acceptance Criteria. Note `.yml`/`.yaml` is not in `SCANNABLE_EXTENSIONS`, so GitHub Actions workflow YAML itself is still gated by the existing scannable-extension filter ("included **when scannable**"); this PR fixes the traversal blind spot for scannable source (`.js`, `.py`, …) within dotpaths. Broadening scannable extensions to YAML is a separate concern with wider performance/noise implications.

## Test plan

- [x] `npx vitest run tests/scan-project.test.js` — 8/8 pass (incl. 2 new)
- [x] `npx vitest run tests/project-scan-to-sarif.test.js tests/scan-diff.test.js tests/project-context.test.js` — 41/41 pass (regression check on directory-walk consumers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)