### PR TITLE
chore(release): 4.4.3 — dependency updates (hono, vitest)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-security-scanner-mcp",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-security-scanner-mcp",
-      "version": "4.4.2",
+      "version": "4.4.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-security-scanner-mcp",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "mcpName": "io.github.sinewaveai/agent-security-scanner-mcp",
   "description": "Security scanner MCP server for AI coding agents. Prompt injection firewall, package hallucination detection (4.3M+ packages), 1700+ vulnerability rules with AST & taint analysis, LLM-powered semantic code review, auto-fix. For Claude Code, Cursor, Windsurf, Cline, OpenClaw.",
   "main": "index.js",


### PR DESCRIPTION
## Summary

Patch release bundling the latest chore dependency bumps merged since v4.4.2.

## Changes since v4.4.2

- chore(deps): bump hono 4.12.18 → 4.12.23 (root) (#97)
- chore(deps): bump hono 4.12.18 → 4.12.23 in /mcp-server-full (#98)
- chore(deps): bump hono 4.12.18 → 4.12.23 in /prooflayer-scanner (#99)
- chore(deps): bump hono 4.12.18 → 4.12.23 in /scanner-lite (#100)
- chore(deps-dev): bump vitest 3.2.4 → 4.1.0 in /code-review-agent (#95)
- chore(deps-dev): bump vitest 3.2.4 → 4.1.0 in /scanner-lite (#94)

## Not included

- #96 (`vitest 4.0.18 → 4.1.0` root) — held because vitest 4.1.0 imports `styleText` from `node:util`, which only exists in Node 20.12+. The repo's `engines.node` is `">=18.0.0"` and CI tests Node 18, so this would require dropping Node 18 support first. Tracked on the PR.

## Test plan

- [x] All six included PRs were green on their own CI before merging
- [ ] CI on this release branch passes