### PR TITLE
chore(release): 4.4.4 — dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-security-scanner-mcp",
-  "version": "4.4.3",
+  "version": "4.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-security-scanner-mcp",
-      "version": "4.4.3",
+      "version": "4.4.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-security-scanner-mcp",
-  "version": "4.4.3",
+  "version": "4.4.4",
   "mcpName": "io.github.sinewaveai/agent-security-scanner-mcp",
   "description": "Security scanner MCP server for AI coding agents. Prompt injection firewall, package hallucination detection (4.3M+ packages), 1700+ vulnerability rules with AST & taint analysis, LLM-powered semantic code review, auto-fix. For Claude Code, Cursor, Windsurf, Cline, OpenClaw.",
   "main": "index.js",


### PR DESCRIPTION
## Summary

Patch release bundling the latest chore dependency bumps merged since v4.4.3.

## Changes since v4.4.3

### Runtime
- chore(deps): bump tar 7.5.11 → 7.5.16 (root) (#112)
- chore(deps): bump hono 4.12.23 → 4.12.26 (root) (#107)
- chore(deps): bump hono 4.12.23 → 4.12.26 in /mcp-server-full (#110)
- chore(deps): bump hono 4.12.23 → 4.12.26 in /prooflayer-scanner (#109)
- chore(deps): bump hono 4.12.23 → 4.12.26 in /scanner-lite (#108)
- chore(deps): bump qs 6.15.0 → 6.15.2 in /mcp-server-full (#101)
- chore(deps): bump form-data 4.0.5 → 4.0.6 in /code-review-agent (#111)

### Dev
- chore(deps-dev): bump vite 7.3.2 → 7.3.5 (#106)
- chore(deps): bump esbuild and tsx in /code-review-agent (#105)

## Not included

- #104 (`esbuild + vitest` → vitest 4.1.8) — vitest 4.1.x imports `styleText` from `node:util` (Node ≥ 20.12 only). Repo's `engines.node` is `">=18.0.0"` and CI tests Node 18. Requires dropping Node 18 first (policy decision); see PR comment.

## Test plan

- [x] All nine included PRs were green on their own CI before merging
- [ ] CI on this release branch passes