### PR TITLE
chore(release): 4.4.5 — version bump for republish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-security-scanner-mcp",
-  "version": "4.4.4",
+  "version": "4.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-security-scanner-mcp",
-      "version": "4.4.4",
+      "version": "4.4.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-security-scanner-mcp",
-  "version": "4.4.4",
+  "version": "4.4.5",
   "mcpName": "io.github.sinewaveai/agent-security-scanner-mcp",
   "description": "Security scanner MCP server for AI coding agents. Prompt injection firewall, package hallucination detection (4.3M+ packages), 1700+ vulnerability rules with AST & taint analysis, LLM-powered semantic code review, auto-fix. For Claude Code, Cursor, Windsurf, Cline, OpenClaw.",
   "main": "index.js",


### PR DESCRIPTION
## Summary

Empty patch release. Tarball contents are byte-identical to [v4.4.4](https://github.com/sinewaveai/agent-security-scanner-mcp/releases/tag/v4.4.4); only the version number changes.

## Why

A fresh, unused version number was requested for the registry. main has no merged commits since v4.4.4 (cut 2026-06-22), so there is no other content to ship.

## Held back

- #104 (`vitest 4.0.18 → 4.1.9` root) — still blocked on Node 18 (`util.styleText` only exists in Node 20.12+). See [comment](https://github.com/sinewaveai/agent-security-scanner-mcp/pull/104#issuecomment-4765918693).