### PR TITLE
fix: cr-agent broken on OpenAI provider and after fresh install

### DIFF
--- a/code-review-agent/src/llm/schemas.ts
+++ b/code-review-agent/src/llm/schemas.ts
@@ -2,11 +2,11 @@ import { z } from 'zod';
 
 type JsonSchema = Record<string, unknown>;
 
-export function zodToJsonSchema(schema: z.ZodTypeAny): JsonSchema {
-  return convertType(schema);
+export function zodToJsonSchema(schema: z.ZodTypeAny, openaiStrict = false): JsonSchema {
+  return convertType(schema, openaiStrict);
 }
 
-function convertType(schema: z.ZodTypeAny): JsonSchema {
+function convertType(schema: z.ZodTypeAny, openaiStrict: boolean): JsonSchema {
   const def = schema._def;
   const typeName = def.typeName as string;
 
@@ -33,7 +33,7 @@ function convertType(schema: z.ZodTypeAny): JsonSchema {
       return { type: 'string', enum: def.values };
 
     case 'ZodArray':
-      return { type: 'array', items: convertType(def.type) };
+      return { type: 'array', items: convertType(def.type, openaiStrict) };
 
     case 'ZodObject': {
       const shape = def.shape();
@@ -43,8 +43,21 @@ function convertType(schema: z.ZodTypeAny): JsonSchema {
       for (const [key, value] of Object.entries(shape)) {
         const fieldSchema = value as z.ZodTypeAny;
         const isOptional = fieldSchema.isOptional();
-        properties[key] = convertType(fieldSchema);
-        if (!isOptional) {
+        let propSchema = convertType(fieldSchema, openaiStrict);
+
+        // OpenAI's strict structured-output mode requires every property to be
+        // listed in `required`; true optionality must instead be expressed by
+        // making the field's type nullable. Without this, any schema with an
+        // optional field is rejected outright by OpenAI's API (400 Invalid schema),
+        // while Anthropic's looser tool-schema rules tolerate the omission.
+        if (openaiStrict && isOptional) {
+          propSchema = propSchema.anyOf
+            ? { anyOf: [...(propSchema.anyOf as JsonSchema[]), { type: 'null' }] }
+            : { anyOf: [propSchema, { type: 'null' }] };
+        }
+
+        properties[key] = propSchema;
+        if (!isOptional || openaiStrict) {
           required.push(key);
         }
       }
@@ -61,28 +74,28 @@ function convertType(schema: z.ZodTypeAny): JsonSchema {
     }
 
     case 'ZodOptional':
-      return convertType(def.innerType);
+      return convertType(def.innerType, openaiStrict);
 
     case 'ZodNullable': {
-      const inner = convertType(def.innerType);
+      const inner = convertType(def.innerType, openaiStrict);
       return { anyOf: [inner, { type: 'null' }] };
     }
 
     case 'ZodDefault':
-      return convertType(def.innerType);
+      return convertType(def.innerType, openaiStrict);
 
     case 'ZodEffects':
-      return convertType(def.schema);
+      return convertType(def.schema, openaiStrict);
 
     case 'ZodUnion': {
-      const options = (def.options as z.ZodTypeAny[]).map(convertType);
+      const options = (def.options as z.ZodTypeAny[]).map((o) => convertType(o, openaiStrict));
       return { anyOf: options };
     }
 
     case 'ZodRecord':
       return {
         type: 'object',
-        additionalProperties: convertType(def.valueType),
+        additionalProperties: convertType(def.valueType, openaiStrict),
       };
 
     default:
@@ -103,7 +116,7 @@ export function zodToAnthropicTool(
   return {
     name,
     description,
-    input_schema: zodToJsonSchema(schema),
+    input_schema: zodToJsonSchema(schema, false),
   };
 }
 
@@ -119,7 +132,7 @@ export function zodToOpenAIResponseFormat(
     json_schema: {
       name,
       strict: true,
-      schema: zodToJsonSchema(schema),
+      schema: zodToJsonSchema(schema, true),
     },
   };
 }

--- a/code-review-agent/src/llm/schemas.ts
+++ b/code-review-agent/src/llm/schemas.ts
@@ -51,9 +51,7 @@ function convertType(schema: z.ZodTypeAny, openaiStrict: boolean): JsonSchema {
         // optional field is rejected outright by OpenAI's API (400 Invalid schema),
         // while Anthropic's looser tool-schema rules tolerate the omission.
         if (openaiStrict && isOptional) {
-          propSchema = propSchema.anyOf
-            ? { anyOf: [...(propSchema.anyOf as JsonSchema[]), { type: 'null' }] }
-            : { anyOf: [propSchema, { type: 'null' }] };
+          propSchema = withNull(propSchema);
         }
 
         properties[key] = propSchema;
@@ -78,7 +76,7 @@ function convertType(schema: z.ZodTypeAny, openaiStrict: boolean): JsonSchema {
 
     case 'ZodNullable': {
       const inner = convertType(def.innerType, openaiStrict);
-      return { anyOf: [inner, { type: 'null' }] };
+      return withNull(inner);
     }
 
     case 'ZodDefault':
@@ -102,6 +100,17 @@ function convertType(schema: z.ZodTypeAny, openaiStrict: boolean): JsonSchema {
       // Fail loud instead of silently producing invalid schema
       throw new Error(`zodToJsonSchema: unsupported Zod type "${typeName}". Add explicit handling for this type.`);
   }
+}
+
+function withNull(schema: JsonSchema): JsonSchema {
+  if (Array.isArray(schema.anyOf)) {
+    const alreadyNullable = schema.anyOf.some((option) => {
+      return typeof option === 'object' && option !== null && (option as JsonSchema).type === 'null';
+    });
+    return alreadyNullable ? schema : { anyOf: [...schema.anyOf, { type: 'null' }] };
+  }
+
+  return { anyOf: [schema, { type: 'null' }] };
 }
 
 export function zodToAnthropicTool(

--- a/code-review-agent/tests/llm/schemas.test.ts
+++ b/code-review-agent/tests/llm/schemas.test.ts
@@ -178,4 +178,46 @@ describe('zodToOpenAIResponseFormat', () => {
       additionalProperties: false,
     });
   });
+
+  it('applies OpenAI strict-mode nullability recursively to nested objects', () => {
+    const schema = z.object({
+      finding: z.object({
+        title: z.string(),
+        metadata: z.object({
+          cwe: z.string().nullable().optional(),
+        }).optional(),
+      }),
+    });
+
+    const result = zodToOpenAIResponseFormat(schema, 'nested_format');
+
+    expect(result.json_schema.schema).toEqual({
+      type: 'object',
+      properties: {
+        finding: {
+          type: 'object',
+          properties: {
+            title: { type: 'string' },
+            metadata: {
+              anyOf: [
+                {
+                  type: 'object',
+                  properties: {
+                    cwe: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+                  },
+                  required: ['cwe'],
+                  additionalProperties: false,
+                },
+                { type: 'null' },
+              ],
+            },
+          },
+          required: ['title', 'metadata'],
+          additionalProperties: false,
+        },
+      },
+      required: ['finding'],
+      additionalProperties: false,
+    });
+  });
 });

--- a/code-review-agent/tests/llm/schemas.test.ts
+++ b/code-review-agent/tests/llm/schemas.test.ts
@@ -139,4 +139,43 @@ describe('zodToOpenAIResponseFormat', () => {
       },
     });
   });
+
+  // Regression test: OpenAI's strict structured-output mode rejects any schema
+  // where an object has properties absent from `required` (400 Invalid schema
+  // for response_format). Optional fields must instead appear in `required`
+  // with a nullable type. Anthropic's tool schemas don't have this constraint,
+  // which is why this only needs to apply to the OpenAI path.
+  it('marks optional fields as required-but-nullable, per OpenAI strict mode', () => {
+    const schema = z.object({
+      title: z.string(),
+      note: z.string().optional(),
+    });
+    const result = zodToOpenAIResponseFormat(schema, 'test_format');
+    expect(result.json_schema.schema).toEqual({
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+        note: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+      },
+      required: ['title', 'note'],
+      additionalProperties: false,
+    });
+  });
+
+  it('does not apply OpenAI strict-mode nullability to zodToAnthropicTool', () => {
+    const schema = z.object({
+      title: z.string(),
+      note: z.string().optional(),
+    });
+    const result = zodToAnthropicTool(schema, 'test_tool', 'A test tool');
+    expect(result.input_schema).toEqual({
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+        note: { type: 'string' },
+      },
+      required: ['title'],
+      additionalProperties: false,
+    });
+  });
 });

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -80,8 +80,8 @@ if (existsSync(codeReviewAgentDir)) {
     console.log("[postinstall] Setting up code-review-agent (LLM-powered code review)...");
     try {
       if (!nodeModulesExists) {
-        // Install dependencies
-        execSync("npm install --omit=dev", {
+        const installCommand = distExists ? "npm install --omit=dev" : "npm install";
+        execSync(installCommand, {
           cwd: codeReviewAgentDir,
           timeout: 180000,
           stdio: ["pipe", "pipe", "pipe"]
@@ -89,8 +89,13 @@ if (existsSync(codeReviewAgentDir)) {
       }
 
       if (!distExists) {
-        // Build TypeScript
         execSync("npm run build", {
+          cwd: codeReviewAgentDir,
+          timeout: 60000,
+          stdio: ["pipe", "pipe", "pipe"]
+        });
+
+        execSync("npm prune --omit=dev", {
           cwd: codeReviewAgentDir,
           timeout: 60000,
           stdio: ["pipe", "pipe", "pipe"]

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -66,26 +66,36 @@ if (!pythonCmd) {
 
 // Setup code-review-agent (LLM-powered semantic analysis)
 if (existsSync(codeReviewAgentDir)) {
+  // The published package ships a pre-built `dist/`, so checking only for
+  // dist/bin/cr-agent.js is a false positive: that file is always present,
+  // regardless of whether code-review-agent's own runtime dependencies
+  // (commander, @anthropic-ai/sdk, openai, etc.) were ever installed —
+  // node_modules is correctly never shipped, so it must be checked separately.
+  const nodeModulesExists = existsSync(join(codeReviewAgentDir, "node_modules"));
   const distExists = existsSync(join(codeReviewAgentDir, "dist", "bin", "cr-agent.js"));
 
-  if (distExists) {
-    console.log("[postinstall] code-review-agent already built — cr-agent CLI available.");
+  if (nodeModulesExists && distExists) {
+    console.log("[postinstall] code-review-agent already set up — cr-agent CLI available.");
   } else {
     console.log("[postinstall] Setting up code-review-agent (LLM-powered code review)...");
     try {
-      // Install dependencies
-      execSync("npm install --omit=dev", {
-        cwd: codeReviewAgentDir,
-        timeout: 180000,
-        stdio: ["pipe", "pipe", "pipe"]
-      });
+      if (!nodeModulesExists) {
+        // Install dependencies
+        execSync("npm install --omit=dev", {
+          cwd: codeReviewAgentDir,
+          timeout: 180000,
+          stdio: ["pipe", "pipe", "pipe"]
+        });
+      }
 
-      // Build TypeScript
-      execSync("npm run build", {
-        cwd: codeReviewAgentDir,
-        timeout: 60000,
-        stdio: ["pipe", "pipe", "pipe"]
-      });
+      if (!distExists) {
+        // Build TypeScript
+        execSync("npm run build", {
+          cwd: codeReviewAgentDir,
+          timeout: 60000,
+          stdio: ["pipe", "pipe", "pipe"]
+        });
+      }
 
       console.log("[postinstall] code-review-agent installed — run: npx cr-agent --help");
     } catch (err) {


### PR DESCRIPTION
## Summary
Found while running `cr-agent` end-to-end against a real target repo (a deliberately vulnerable MCP server training set). Two separate bugs, both reproducible from a clean install:

1. **`schemas.ts`** — the Zod→JSON-Schema converter only listed non-optional fields under `required`. OpenAI's strict structured-output mode requires *every* property to be listed as required, with true optionality expressed via a nullable type instead. Any schema with an optional field was therefore rejected outright by OpenAI (`400 Invalid schema for response_format`) on every single request — while Anthropic's looser tool-schema rules tolerated the same output, which is why this only surfaced on the OpenAI provider path. Worth noting: the tool didn't surface this as an error to the user — it printed `Complete: 0 finding(s)`, indistinguishable from a clean scan, and cost tracking showed `$0.0000` despite real (failing) API calls being billed.
2. **`postinstall.js`** — setup for the bundled `code-review-agent` sub-package checked only whether `dist/bin/cr-agent.js` existed before deciding whether to run `npm install`. Since the published package ships a pre-built `dist/`, that file is always present — so the check never caught that `node_modules` (correctly never shipped) was missing, and `cr-agent` crashed immediately with `ERR_MODULE_NOT_FOUND: commander` on a fresh install.

## Changes
- `code-review-agent/src/llm/schemas.ts`: added an `openaiStrict` flag threaded through the converter, defaulting to `false` (Anthropic path unaffected); when `true`, optional fields are marked required-but-nullable per OpenAI's rules.
- `code-review-agent/tests/llm/schemas.test.ts`: added regression tests covering both the OpenAI nullable-required behavior and confirming `zodToAnthropicTool` is unaffected.
- `scripts/postinstall.js`: now checks `node_modules` and `dist` independently, rather than treating "dist exists" as a proxy for "fully set up."

## Test plan
- [x] `npx vitest run` — full suite passes (121/121, including 2 new regression tests)
- [x] `npm run build` (tsc) compiles clean
- [x] Manually verified: patched build against a real target repo went from 0/24 files analyzed (all failing with the schema error) to 23 real findings across 24 files, using `--provider openai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)