### PR TITLE
fix: reduce Apify quick scan fixture noise

### DIFF
--- a/.actor/README.md
+++ b/.actor/README.md
@@ -22,6 +22,8 @@ This Actor does not continuously monitor a target after the run finishes. Re-run
 
 Repository scans default to `quick`, a fast rule-based pass designed for hosted Apify runs and first-look triage. Set `repositoryScanMode` to `analyzer` when you need deeper per-file analysis and are willing to trade runtime for coverage.
 
+By default, repository scans skip tests, demos, benchmarks, and fixtures so intentionally vulnerable examples do not swamp the dataset. Set `includeTestFiles` to `true` when you want to audit those paths too; quick-mode findings from those paths are marked lower confidence.
+
 ## Example Inputs
 
 Scan a repository:
@@ -32,6 +34,7 @@ Scan a repository:
   "repoUrl": "https://github.com/modelcontextprotocol/servers.git",
   "branch": "main",
   "repositoryScanMode": "quick",
+  "includeTestFiles": false,
   "maxRepositoryFiles": 150,
   "perFileTimeoutSeconds": 30,
   "severityThreshold": "medium",
@@ -78,6 +81,7 @@ When using Apify MCP tools, call the Actor with the same JSON input shape. For e
     "target": "repository",
     "repoUrl": "https://github.com/your-org/your-agent.git",
     "repositoryScanMode": "quick",
+    "includeTestFiles": false,
     "maxRepositoryFiles": 150,
     "perFileTimeoutSeconds": 30,
     "severityThreshold": "medium",

--- a/.actor/input_schema.json
+++ b/.actor/input_schema.json
@@ -84,6 +84,13 @@
       "enumTitles": ["Quick rules (fast)", "Analyzer (deeper)"],
       "default": "quick"
     },
+    "includeTestFiles": {
+      "title": "Include Test, Demo, and Fixture Files",
+      "description": "Include tests, demos, benchmarks, and fixtures in repository scans. Disabled by default to reduce noisy findings from intentionally vulnerable examples.",
+      "type": "boolean",
+      "editor": "checkbox",
+      "default": false
+    },
     "maxRepositoryFiles": {
       "title": "Max Repository Files",
       "description": "Maximum number of source files to scan for repository targets. Lower values finish faster on large repositories; maximum is 500.",

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,7 @@ const DEFAULT_REPOSITORY_SCAN_FILE_LIMIT = 150;
 const MAX_REPOSITORY_SCAN_FILE_LIMIT = 500;
 const DEFAULT_REPOSITORY_FILE_TIMEOUT_SECONDS = 30;
 const MAX_REPOSITORY_FILE_TIMEOUT_SECONDS = 120;
+const DEFAULT_INCLUDE_TEST_FILES = false;
 const REPOSITORY_SCAN_EXTENSIONS = new Set([
   '.py', '.js', '.ts', '.tsx', '.jsx', '.java', '.go', '.rb', '.php',
   '.rs', '.c', '.cpp', '.cc', '.cxx', '.h', '.hpp', '.cs',
@@ -25,6 +26,17 @@ const REPOSITORY_SCAN_SKIP_DIRS = new Set([
   '.git', 'node_modules', 'vendor', 'dist', 'build', 'coverage', '.next',
   '.nuxt', '.venv', 'venv', 'env', '__pycache__', '.pytest_cache'
 ]);
+const REPOSITORY_TEST_DIRS = new Set([
+  '__fixtures__', '__mocks__', '__tests__', 'benchmark', 'benchmarks',
+  'demo', 'demos', 'fixture', 'fixtures', 'mock', 'mocks', 'spec',
+  'test', 'tests'
+]);
+const REPOSITORY_TEST_FILE_PATTERNS = [
+  /\.(?:test|spec)\.[cm]?[jt]sx?$/i,
+  /(?:^|[\\/])test_[^\\/]+\.py$/i,
+  /(?:^|[\\/])[^\\/]+_test\.py$/i,
+  /(?:^|[\\/])conftest\.py$/i
+];
 const DEFAULT_REPOSITORY_SCAN_MODE = 'quick';
 const REPOSITORY_SCAN_MODES = new Set(['quick', 'analyzer']);
 const QUICK_FINDINGS_PER_FILE_LIMIT = 20;
@@ -191,6 +203,8 @@ export function normalizeFinding(finding, index, options = {}) {
       file,
       line: typeof line === 'number' ? line : undefined
     },
+    confidence: finding.confidence || finding.metadata?.confidence,
+    sourceContext: finding.sourceContext || finding.metadata?.source_context,
     owaspLlm: finding.owaspLlm || finding.owasp_llm || finding.metadata?.owasp_llm || inferOwaspLlm(finding),
     mitreAtlas: finding.mitreAtlas || finding.mitre_atlas || finding.metadata?.mitre_atlas || inferMitreAtlas(finding),
     remediation: options.includeRemediation ? remediationFor(finding) : undefined
@@ -287,6 +301,8 @@ export function createSummary({ input, scannerOutput, findings, source }) {
     sarifKey: 'report.sarif',
     scanMode: scannerOutput.scan_mode || null,
     repositoryScanMode: scannerOutput.repository_scan_mode || null,
+    includeTestFiles: scannerOutput.include_test_files ?? null,
+    excludedFiles: scannerOutput.excluded_files || 0,
     capped: Boolean(scannerOutput.capped),
     scanLimit: scannerOutput.scan_limit || null,
     perFileTimeoutSeconds: scannerOutput.per_file_timeout_seconds || null,
@@ -368,9 +384,28 @@ function normalizeRepositoryScanMode(value) {
   return REPOSITORY_SCAN_MODES.has(value) ? value : DEFAULT_REPOSITORY_SCAN_MODE;
 }
 
-async function collectRepositoryFiles(rootDir, fileLimit = DEFAULT_REPOSITORY_SCAN_FILE_LIMIT) {
+function normalizeBooleanOption(value, defaultValue) {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) return true;
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) return false;
+  }
+  return defaultValue;
+}
+
+function isRepositoryTestPath(relativeFile) {
+  const normalizedPath = relativeFile.replaceAll('\\', '/');
+  const parts = normalizedPath.split('/').map((part) => part.toLowerCase());
+  if (parts.some((part) => REPOSITORY_TEST_DIRS.has(part))) return true;
+  return REPOSITORY_TEST_FILE_PATTERNS.some((pattern) => pattern.test(normalizedPath));
+}
+
+async function collectRepositoryFiles(rootDir, fileLimit = DEFAULT_REPOSITORY_SCAN_FILE_LIMIT, options = {}) {
   const files = [];
   const skipped = [];
+  const excluded = [];
+  const includeTestFiles = normalizeBooleanOption(options.includeTestFiles, DEFAULT_INCLUDE_TEST_FILES);
 
   async function walk(currentDir) {
     if (files.length >= fileLimit) return;
@@ -389,20 +424,30 @@ async function collectRepositoryFiles(rootDir, fileLimit = DEFAULT_REPOSITORY_SC
     for (const entry of entries) {
       if (files.length >= fileLimit) return;
       const fullPath = join(currentDir, entry.name);
+      const relativePath = relative(rootDir, fullPath) || entry.name;
       if (entry.isDirectory()) {
-        if (!REPOSITORY_SCAN_SKIP_DIRS.has(entry.name)) await walk(fullPath);
+        if (REPOSITORY_SCAN_SKIP_DIRS.has(entry.name)) continue;
+        if (!includeTestFiles && isRepositoryTestPath(relativePath)) {
+          excluded.push(relativePath);
+          continue;
+        }
+        await walk(fullPath);
         continue;
       }
       if (!entry.isFile() || !isScannableRepositoryFile(fullPath)) continue;
+      if (!includeTestFiles && isRepositoryTestPath(relativePath)) {
+        excluded.push(relativePath);
+        continue;
+      }
 
       try {
         const fileStat = await stat(fullPath);
         if (fileStat.size > 1024 * 1024) {
-          skipped.push({ path: relative(rootDir, fullPath), reason: 'File larger than 1MB' });
+          skipped.push({ path: relativePath, reason: 'File larger than 1MB' });
           continue;
         }
       } catch (error) {
-        skipped.push({ path: relative(rootDir, fullPath), reason: error.message });
+        skipped.push({ path: relativePath, reason: error.message });
         continue;
       }
 
@@ -411,7 +456,7 @@ async function collectRepositoryFiles(rootDir, fileLimit = DEFAULT_REPOSITORY_SC
   }
 
   await walk(rootDir);
-  return { files, skipped, capped: files.length >= fileLimit };
+  return { files, skipped, excluded, capped: files.length >= fileLimit };
 }
 
 function calculateRepositoryGrade(issueCount, fileCount, errorCount) {
@@ -451,6 +496,7 @@ async function scanRepositoryFileQuick(filePath, relativeFile) {
   const content = await readFile(filePath, 'utf8');
   const findings = [];
   const lines = content.split(/\r?\n/);
+  const isTestPath = isRepositoryTestPath(relativeFile);
 
   for (const [lineIndex, line] of lines.entries()) {
     if (findings.length >= QUICK_FINDINGS_PER_FILE_LIMIT) break;
@@ -461,11 +507,12 @@ async function scanRepositoryFileQuick(filePath, relativeFile) {
         line: lineIndex + 1,
         ruleId: `apify.quick.${rule.id}`,
         severity: rule.severity,
-        confidence: 'MEDIUM',
+        confidence: isTestPath ? 'LOW' : 'MEDIUM',
         message: rule.message,
         file: relativeFile,
         metadata: {
-          category: rule.category
+          category: rule.category,
+          source_context: isTestPath ? 'test_or_fixture' : 'source'
         }
       });
     }
@@ -478,15 +525,17 @@ async function scanRepositoryForActor(directoryPath, options = {}) {
   const fileLimit = normalizeRepositoryFileLimit(options.maxRepositoryFiles);
   const perFileTimeoutSeconds = normalizeRepositoryFileTimeout(options.perFileTimeoutSeconds);
   const scanMode = normalizeRepositoryScanMode(options.repositoryScanMode);
-  const { files, skipped, capped } = await collectRepositoryFiles(directoryPath, fileLimit);
+  const includeTestFiles = normalizeBooleanOption(options.includeTestFiles, DEFAULT_INCLUDE_TEST_FILES);
+  const { files, skipped, excluded, capped } = await collectRepositoryFiles(directoryPath, fileLimit, { includeTestFiles });
   const issues = [];
   const scanErrors = [...skipped];
   const bySeverity = { error: 0, warning: 0, info: 0 };
   const byCategory = {};
   const byFile = {};
 
-  console.log(`[Apify] Repository scan discovered ${files.length} file(s); mode=${scanMode}; limit=${fileLimit}; capped=${capped}; perFileTimeout=${perFileTimeoutSeconds}s`);
+  console.log(`[Apify] Repository scan discovered ${files.length} file(s); mode=${scanMode}; includeTestFiles=${includeTestFiles}; excluded=${excluded.length}; limit=${fileLimit}; capped=${capped}; perFileTimeout=${perFileTimeoutSeconds}s`);
   if (skipped.length > 0) console.log(`[Apify] Skipped ${skipped.length} file(s) before scan.`);
+  if (excluded.length > 0) console.log(`[Apify] Excluded ${excluded.length} test/demo/benchmark/fixture path(s).`);
 
   await writeRepositoryProgress({
     scanMode: scanMode === 'quick' ? 'apify-repository-quick' : 'apify-repository-analyzer',
@@ -496,6 +545,8 @@ async function scanRepositoryForActor(directoryPath, options = {}) {
     issuesCount: 0,
     capped,
     scanLimit: fileLimit,
+    includeTestFiles,
+    excludedFiles: excluded.length,
     perFileTimeoutSeconds,
     scanErrors: scanErrors.slice(0, 25)
   });
@@ -514,6 +565,8 @@ async function scanRepositoryForActor(directoryPath, options = {}) {
       issuesCount: issues.length,
       capped,
       scanLimit: fileLimit,
+      includeTestFiles,
+      excludedFiles: excluded.length,
       perFileTimeoutSeconds,
       scanErrors: scanErrors.slice(0, 25)
     });
@@ -559,6 +612,8 @@ async function scanRepositoryForActor(directoryPath, options = {}) {
       issuesCount: issues.length,
       capped,
       scanLimit: fileLimit,
+      includeTestFiles,
+      excludedFiles: excluded.length,
       perFileTimeoutSeconds,
       currentFile: relativeFile,
       scanErrors: scanErrors.slice(0, 25)
@@ -569,6 +624,9 @@ async function scanRepositoryForActor(directoryPath, options = {}) {
     directory: directoryPath,
     scan_mode: scanMode === 'quick' ? 'apify-repository-quick' : 'apify-repository-analyzer',
     repository_scan_mode: scanMode,
+    include_test_files: includeTestFiles,
+    excluded_files: excluded.length,
+    excluded_file_examples: excluded.slice(0, 25),
     files_scanned: files.length,
     scan_limit: fileLimit,
     per_file_timeout_seconds: perFileTimeoutSeconds,
@@ -620,7 +678,8 @@ export async function runActor(input) {
       preparedTarget.options = {
         maxRepositoryFiles: normalizedInput.maxRepositoryFiles,
         perFileTimeoutSeconds: normalizedInput.perFileTimeoutSeconds,
-        repositoryScanMode: normalizedInput.repositoryScanMode
+        repositoryScanMode: normalizedInput.repositoryScanMode,
+        includeTestFiles: normalizedInput.includeTestFiles
       };
     }
     const scannerOutput = await runScanner(preparedTarget);
@@ -658,6 +717,8 @@ export async function runActor(input) {
       issuesCount: summary.findingsCount,
       capped: summary.capped,
       scanLimit: summary.scanLimit,
+      includeTestFiles: summary.includeTestFiles,
+      excludedFiles: summary.excludedFiles,
       perFileTimeoutSeconds: summary.perFileTimeoutSeconds,
       scanErrors: summary.scanErrors.slice(0, 25)
     });

--- a/tests/apify-actor.test.js
+++ b/tests/apify-actor.test.js
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import {
   createSarif,
   createSummary,
   normalizeScannerOutput,
-  normalizeSeverity
+  normalizeSeverity,
+  runScanner
 } from '../src/main.js';
 
 describe('Apify Actor wrapper', () => {
@@ -95,6 +99,8 @@ describe('Apify Actor wrapper', () => {
     expect(summary.sarifKey).toBe('report.sarif');
     expect(summary.scanMode).toBe('apify-repository-quick');
     expect(summary.repositoryScanMode).toBe('quick');
+    expect(summary.includeTestFiles).toBeNull();
+    expect(summary.excludedFiles).toBe(0);
     expect(summary.capped).toBe(true);
     expect(summary.scanLimit).toBe(150);
     expect(summary.perFileTimeoutSeconds).toBe(30);
@@ -108,5 +114,72 @@ describe('Apify Actor wrapper', () => {
     expect(normalizeSeverity('WARNING')).toBe('medium');
     expect(normalizeSeverity('INFO')).toBe('info');
     expect(normalizeSeverity('critical')).toBe('critical');
+  });
+
+  it('excludes test, demo, benchmark, and fixture files from repository quick scans by default', async () => {
+    const repoDir = await mkdtemp(join(tmpdir(), 'apify-noise-filter-'));
+    try {
+      await mkdir(join(repoDir, 'src'), { recursive: true });
+      await mkdir(join(repoDir, 'tests'), { recursive: true });
+      await mkdir(join(repoDir, 'demo'), { recursive: true });
+      await writeFile(join(repoDir, 'src', 'agent.js'), 'eval(userInput);\n', 'utf8');
+      await writeFile(join(repoDir, 'tests', 'agent.test.js'), 'eval(testInput);\n', 'utf8');
+      await writeFile(join(repoDir, 'demo', 'unsafe-demo.js'), 'eval(demoInput);\n', 'utf8');
+
+      const result = await runScanner({
+        kind: 'repository',
+        path: repoDir,
+        options: { maxRepositoryFiles: 10, repositoryScanMode: 'quick' }
+      });
+
+      expect(result.scan_mode).toBe('apify-repository-quick');
+      expect(result.include_test_files).toBe(false);
+      expect(result.files_scanned).toBe(1);
+      expect(result.issues_count).toBe(1);
+      expect(result.excluded_files).toBe(2);
+      expect(result.scanned_files).toEqual(['src/agent.js']);
+      expect(result.issues[0]).toMatchObject({
+        file: 'src/agent.js',
+        confidence: 'MEDIUM',
+        metadata: { source_context: 'source' }
+      });
+    } finally {
+      await rm(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it('can include test, demo, benchmark, and fixture files with low confidence context', async () => {
+    const repoDir = await mkdtemp(join(tmpdir(), 'apify-noise-filter-'));
+    try {
+      await mkdir(join(repoDir, 'src'), { recursive: true });
+      await mkdir(join(repoDir, 'tests'), { recursive: true });
+      await mkdir(join(repoDir, 'demo'), { recursive: true });
+      await writeFile(join(repoDir, 'src', 'agent.js'), 'eval(userInput);\n', 'utf8');
+      await writeFile(join(repoDir, 'tests', 'agent.test.js'), 'eval(testInput);\n', 'utf8');
+      await writeFile(join(repoDir, 'demo', 'unsafe-demo.js'), 'eval(demoInput);\n', 'utf8');
+
+      const result = await runScanner({
+        kind: 'repository',
+        path: repoDir,
+        options: { maxRepositoryFiles: 10, repositoryScanMode: 'quick', includeTestFiles: true }
+      });
+
+      expect(result.include_test_files).toBe(true);
+      expect(result.files_scanned).toBe(3);
+      expect(result.issues_count).toBe(3);
+      expect(result.excluded_files).toBe(0);
+      expect(result.scanned_files).toEqual(['demo/unsafe-demo.js', 'src/agent.js', 'tests/agent.test.js']);
+      expect(result.issues.find((issue) => issue.file === 'src/agent.js')?.confidence).toBe('MEDIUM');
+      expect(result.issues.find((issue) => issue.file === 'tests/agent.test.js')).toMatchObject({
+        confidence: 'LOW',
+        metadata: { source_context: 'test_or_fixture' }
+      });
+      expect(result.issues.find((issue) => issue.file === 'demo/unsafe-demo.js')).toMatchObject({
+        confidence: 'LOW',
+        metadata: { source_context: 'test_or_fixture' }
+      });
+    } finally {
+      await rm(repoDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- skip tests, demos, benchmarks, and fixtures by default in Apify repository scans
- add includeTestFiles input to opt back into those paths
- mark quick-mode findings from included test/fixture paths as LOW confidence with sourceContext metadata
- surface includeTestFiles and excludedFiles in OUTPUT/PROGRESS summaries

## Validation
- npx vitest run tests/apify-actor.test.js
- node index.js scan-security src/main.js --verbosity compact
- node index.js scan-security tests/apify-actor.test.js --verbosity compact
- node index.js scan-security .actor/input_schema.json --verbosity compact
- local 150-file quick scan: 228 -> 171 findings with test/demo/benchmark/fixture filtering
- docker build -t prooflayer-agent-security-scanner-apify:noise-filter .
- docker container smoke: source file scanned, test file excluded
- npm test (63 files, 1121 tests)